### PR TITLE
Custom domains support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2019-02-28
+## [2.2.0] - 2019-02-28
 
 ### Added
 - Custom domains support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2019-02-28
+
+### Added
+- Custom domains support
+
 ## [2.1.1] - 2019-02-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "This extension provides your users with a dashboard for all of their applications.",
   "engines": {
     "node": ">=4.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "This extension provides your users with a dashboard for all of their applications.",
   "engines": {
     "node": ">=4.x"

--- a/server/lib/authenticationUrl.js
+++ b/server/lib/authenticationUrl.js
@@ -3,7 +3,7 @@ import config from './config';
 module.exports = (app) => {
   const authProtocol = app.type;
   const callback = app.callback || '';
-  const domain = config('AUTH0_DOMAIN');
+  const domain = config('AUTH0_ISSUER_DOMAIN');
   const clientId = app.client;
   const responseType = app.response_type || 'code';
   const scope = app.scope || 'openid';

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -20,6 +20,10 @@ const config = (key) => {
     throw new Error('A configuration provider has not been set');
   }
 
+  if (key === 'AUTH0_ISSUER_DOMAIN') {
+    return currentProvider('AUTH0_ISSUER_DOMAIN') || currentProvider('AUTH0_DOMAIN');
+  }
+
   return boolify(currentProvider(key));
 };
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -13,7 +13,7 @@ export default (storage) => {
 
   // Allow end users to authenticate.
   api.use(middlewares.authenticateUsers.optional({
-    domain: config('AUTH0_DOMAIN'),
+    domain: config('AUTH0_ISSUER_DOMAIN'),
     audience: config('API_AUDIENCE') || 'urn:auth0-sso-dashboard',
     credentialsRequired: false,
     onLoginSuccess: (req, res, next) => {

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -45,7 +45,7 @@ export default () => {
     }
 
     const settings = {
-      AUTH0_DOMAIN: config('AUTH0_DOMAIN'),
+      AUTH0_DOMAIN: config('AUTH0_ISSUER_DOMAIN'),
       AUTH0_CLIENT_ID: config('EXTENSION_CLIENT_ID'),
       AUTH0_MANAGE_URL: config('AUTH0_MANAGE_URL') || 'https://manage.auth0.com',
       ALLOW_AUTHZ: config('ALLOW_AUTHZ'),

--- a/webtask.json
+++ b/webtask.json
@@ -1,8 +1,8 @@
 {
   "title": "SSO Dashboard",
   "name": "auth0-sso-dashboard",
-  "version": "2.1.2",
-  "preVersion": "1.1.6",
+  "version": "2.2.0",
+  "preVersion": "2.1.1",
   "author": "Auth0",
   "useHashName": false,
   "description": "This extension provides your users with a dashboard for all of their applications.",

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "SSO Dashboard",
   "name": "auth0-sso-dashboard",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "preVersion": "1.1.6",
   "author": "Auth0",
   "useHashName": false,
@@ -35,6 +35,11 @@
     "CUSTOM_CSS": {
       "description": "A CSS file containing custom styles for the extension",
       "example": "https://cdn.fabrikam.com/static/extensions/theme/fabrikam.css",
+      "required": false
+    },
+    "AUTH0_ISSUER_DOMAIN": {
+      "description": "Custom domain",
+      "example": "https://example.com",
       "required": false
     },
     "ALLOW_AUTHZ": {


### PR DESCRIPTION
## ✏️ Changes
  New `AUTH0_ISSUER_DOMAIN` secret has been added and exposed in the `webtask.json`. This secret can be used instead of `AUTH0_DOMAIN` to support custom domains.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1550872231026300
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
  This can be deployed at any time, BUT `AUTH0_ISSUER_DOMAIN` will be exposed to all customers, regardless they have or have not custom domain enabled. 
  