### PR TITLE
sort order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2019-02-28
+## [2.2.0] - 2019-03-01
 
 ### Added
 - Custom domains support
+
+### Fixed
+- Applications sort order issue fixed
 
 ## [2.1.1] - 2019-02-19
 

--- a/client/components/Applications/ApplicationsList.jsx
+++ b/client/components/Applications/ApplicationsList.jsx
@@ -20,8 +20,9 @@ export default class ApplicationsList extends Component {
       <div>
         {Object.keys(applications).map((key) => {
           const app = applications[key];
+          const appId = applications[key].id || key;
           const logo = (app.logo) ? app.logo : 'https://cdn.auth0.com/manage/v0.3.1866/img/badge-grey.svg';
-          const name = app.name || key;
+          const name = app.name || appId;
 
           const link = app.customURLEnabled ? varstring(app.customURL || '', {
             domain: window.config.AUTH0_DOMAIN,
@@ -31,7 +32,7 @@ export default class ApplicationsList extends Component {
           }) : app.loginUrl;
 
           return (
-            <a href={link} rel="noopener noreferrer" target="_blank" key={key}>
+            <a href={link} rel="noopener noreferrer" target="_blank" key={appId}>
               <div className="user-app">
                 <div className="image-container">
                   <img className="img-circle" src={logo} alt={name} width="32" />

--- a/client/components/Applications/ApplicationsTable.jsx
+++ b/client/components/Applications/ApplicationsTable.jsx
@@ -78,6 +78,7 @@ export default class ApplicationsTable extends Component {
           <TableBody>
             {Object.keys(applications).map((key) => {
               const application = applications[key];
+              const applicationId = applications[key].id;
               const logo = application.logo || 'https://cdn.auth0.com/manage/v0.3.1866/img/badge-grey.svg';
               const type = application.type;
               const enabled = application.enabled;
@@ -87,14 +88,14 @@ export default class ApplicationsTable extends Component {
               const loginUrl = application.loginUrl;
               rowIndex++;
               return (
-                <TableRow key={key}>
+                <TableRow key={applicationId}>
                   <TableCell>
                     <div>
                       <div className="logoBlockImage">
                         <img src={logo} alt={name} />
                       </div>
                       <div className="logoBlockInfo">
-                        <Link to={`/applications/${key}`}>
+                        <Link to={`/applications/${applicationId}`}>
                           <span className="application-name">{name}</span>
                         </Link>
                         <span className="application-type">{type}</span>
@@ -105,26 +106,26 @@ export default class ApplicationsTable extends Component {
                     <ul className="list-inline list-inline-apps">
                       <div
                         className={appClassName}
-                        onClick={() => this.enableDisableApp(key, application, enabled)}
+                        onClick={() => this.enableDisableApp(applicationId, application, enabled)}
                       >
                         {appButtonText}
                       </div>
                       <li title="Login" data-toggle="tooltip">
-                        <a href={loginUrl} target="_blank" key={key}>
+                        <a href={loginUrl} target="_blank" key={applicationId}>
                           <i className="icon-budicon-187" />
                         </a>
                       </li>
-                      {this.renderMoveButton(key, 'up', rowIndex, rowsTotal)}
-                      {this.renderMoveButton(key, 'down', rowIndex, rowsTotal)}
+                      {this.renderMoveButton(applicationId, 'up', rowIndex, rowsTotal)}
+                      {this.renderMoveButton(applicationId, 'down', rowIndex, rowsTotal)}
                       <li title="Edit" data-toggle="tooltip">
-                        <Link to={`/applications/${key}`}>
+                        <Link to={`/applications/${applicationId}`}>
                           <i className="icon-budicon-329" />
                         </Link>
                       </li>
                       <li title="Remove" data-toggle="tooltip">
                         <a
                           href="#" onClick={(e) => {
-                            this.props.requestDeleteApplication(key);
+                            this.props.requestDeleteApplication(applicationId);
                           }} className="remove-rule"
                         >
                           <i className="icon-budicon-471" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,7 +802,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.44.tgz",
+      "resolved": "http://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.44.tgz",
       "integrity": "sha512-1NrDPMboC3FzaNdgT11CbX5owPPBlSRMT5XnrJ2KgB1ejKwa5dRhAWLCjP+MV77675Air7Gk+NVvec0G1GgxDg==",
       "dev": true,
       "requires": {
@@ -811,7 +811,7 @@
       "dependencies": {
         "@babel/helper-plugin-utils": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz",
           "integrity": "sha512-k0hZ8w9N3b0Psmlw0bB7U9Hwqc+/hh7yOPFyLi5KAX9pRZ9i+UbTg6DxsVLVuITvF/M1UZNrq7vatrlEw/IPMg==",
           "dev": true
         }
@@ -1273,7 +1273,7 @@
     },
     "@babel/polyfill": {
       "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.44.tgz",
+      "resolved": "http://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.44.tgz",
       "integrity": "sha512-jMLXiCX5FdmAVqOxsjVfeIMbHAHxcvSegpJghNiuIjjqqyWJOAALRB8fsk6FrQCivdcn1r9e/kEaDv3n47MuxA==",
       "dev": true,
       "requires": {
@@ -1382,7 +1382,7 @@
     },
     "@babel/register": {
       "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.44.tgz",
+      "resolved": "http://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.44.tgz",
       "integrity": "sha512-7DlnSyWKnBE+MS+mFPsp5T+2+vz9d5GUDwIJtyCdKGeYkme6uakFVH7qpp4eMpYc47wTANoVbCEDugRQXUeTzg==",
       "dev": true,
       "requires": {
@@ -2290,9 +2290,9 @@
       }
     },
     "auth0-extension-express-tools": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/auth0-extension-express-tools/-/auth0-extension-express-tools-1.1.7.tgz",
-      "integrity": "sha1-I2meTCLZPLw474UMn6kOFjg5kHA=",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/auth0-extension-express-tools/-/auth0-extension-express-tools-1.1.9.tgz",
+      "integrity": "sha512-I4gr0LNYI9doNrIcS29OPzaXTjXbWHUPLOQrfCmL45XjT27MqlYvyBoZo9Pfx+eNec3ek6eUtttu9SDkjunv7A==",
       "requires": {
         "auth0-extension-tools": "^1.3.0",
         "cookie-parser": "^1.4.3",
@@ -2305,14 +2305,14 @@
       }
     },
     "auth0-extension-tools": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/auth0-extension-tools/-/auth0-extension-tools-1.3.1.tgz",
-      "integrity": "sha1-xKi79A8pCQdyHhD0PHrt6t+mkxM=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/auth0-extension-tools/-/auth0-extension-tools-1.3.3.tgz",
+      "integrity": "sha512-Sz3fGYAxyjeKsDuTz2sZStsU8N5ahXPGgExpSuqiIF3m6nLidefY/MgzChsoxWFbTJEIkW3YH7/Z4e8Ag7yc1A==",
       "requires": {
         "async": "2.1.2",
         "auth0": "^2.9.1",
         "bluebird": "^3.4.1",
-        "jsonwebtoken": "^7.1.9",
+        "jsonwebtoken": "^8.3.0",
         "jwks-rsa": "^1.1.1",
         "lodash": "^4.15.0",
         "lru-memoizer": "^1.7.0",
@@ -2320,7 +2320,7 @@
         "node-uuid": "^1.4.7",
         "promise-retry": "^1.1.1",
         "superagent": "^2.2.0",
-        "webtask-tools": "^2.2.0"
+        "webtask-tools": "^3.2.0"
       },
       "dependencies": {
         "async": {
@@ -2332,15 +2332,17 @@
           }
         },
         "auth0": {
-          "version": "2.9.1",
-          "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.9.1.tgz",
-          "integrity": "sha1-heCIA18pkl7QhtqU2BEoimX1g1w=",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.14.0.tgz",
+          "integrity": "sha512-45qHnouulFEcqef1oIRgh5QDKXgV71peWITUX7gbA+lwPv1OIssIP3Dv8ypsBdBJmKwpCW1J/FO/+3GGx8j0ig==",
           "requires": {
             "bluebird": "^2.10.2",
+            "jsonwebtoken": "^8.3.0",
+            "jwks-rsa": "^1.3.0",
             "lru-memoizer": "^1.11.1",
             "object.assign": "^4.0.4",
             "request": "^2.83.0",
-            "rest-facade": "^1.10.0",
+            "rest-facade": "^1.10.1",
             "retry": "^0.10.1"
           },
           "dependencies": {
@@ -2348,6 +2350,19 @@
               "version": "2.11.0",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
               "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+            },
+            "jwks-rsa": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.4.0.tgz",
+              "integrity": "sha512-6aUc+oTuqsLwIarfq3A0FqoD5LFSgveW5JO1uX2s0J8TJuOEcDc4NIMZAmVHO8tMHDw7CwOPzXF/9QhfOpOElA==",
+              "requires": {
+                "@types/express-jwt": "0.0.34",
+                "debug": "^2.2.0",
+                "limiter": "^1.1.0",
+                "lru-memoizer": "^1.6.0",
+                "ms": "^2.0.0",
+                "request": "^2.73.0"
+              }
             },
             "lru-memoizer": {
               "version": "1.12.0",
@@ -2359,31 +2374,108 @@
                 "lru-cache": "~4.0.0",
                 "very-fast-args": "^1.1.0"
               }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             }
           }
         },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "hoek": "2.x.x"
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        "formidable": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+          "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+        },
+        "jsonwebtoken": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+          "integrity": "sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==",
+          "requires": {
+            "jws": "^3.2.1",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            }
+          }
+        },
+        "jwa": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz",
+          "integrity": "sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+          "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+          "requires": {
+            "jwa": "^1.2.0",
+            "safe-buffer": "^5.0.1"
+          }
         },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "rest-facade": {
           "version": "1.10.1",
@@ -2402,29 +2494,50 @@
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
               "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
             },
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            },
             "superagent": {
-              "version": "3.8.2",
-              "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-              "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+              "version": "3.8.3",
+              "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+              "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
               "requires": {
                 "component-emitter": "^1.2.0",
                 "cookiejar": "^2.1.0",
                 "debug": "^3.1.0",
                 "extend": "^3.0.0",
                 "form-data": "^2.3.1",
-                "formidable": "^1.1.1",
+                "formidable": "^1.2.0",
                 "methods": "^1.1.1",
                 "mime": "^1.4.1",
                 "qs": "^6.5.1",
-                "readable-stream": "^2.0.5"
+                "readable-stream": "^2.3.5"
               }
             }
           }
         },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         },
         "superagent": {
           "version": "2.3.0",
@@ -2448,14 +2561,6 @@
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
               "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "form-data": {
               "version": "1.0.0-rc4",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
@@ -2464,117 +2569,6 @@
                 "async": "^1.5.2",
                 "combined-stream": "^1.0.5",
                 "mime-types": "^2.1.10"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "webtask-tools": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/webtask-tools/-/webtask-tools-2.2.0.tgz",
-          "integrity": "sha1-/xtgjKy9CZNtm6ycs9jpkuKl6Fk=",
-          "requires": {
-            "boom": "^2.7.2",
-            "jsonwebtoken": "^5.7.0",
-            "superagent": "^1.8.3"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "cookiejar": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-              "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
-              "requires": {
-                "async": "^1.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.3"
-              }
-            },
-            "formidable": {
-              "version": "1.0.17",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
-            },
-            "jsonwebtoken": {
-              "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
-              "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
-              "requires": {
-                "jws": "^3.0.0",
-                "ms": "^0.7.1",
-                "xtend": "^4.0.1"
-              }
-            },
-            "mime": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
-            },
-            "qs": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
-            },
-            "readable-stream": {
-              "version": "1.0.27-1",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-              "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "superagent": {
-              "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
-              "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
-              "requires": {
-                "component-emitter": "~1.2.0",
-                "cookiejar": "2.0.6",
-                "debug": "2",
-                "extend": "3.0.0",
-                "form-data": "1.0.0-rc3",
-                "formidable": "~1.0.14",
-                "methods": "~1.1.1",
-                "mime": "1.3.4",
-                "qs": "2.3.3",
-                "readable-stream": "1.0.27-1",
-                "reduce-component": "1.0.1"
               }
             }
           }
@@ -2671,7 +2665,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
           "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
           "dev": true,
           "requires": {
@@ -2680,7 +2674,7 @@
         },
         "@babel/helper-function-name": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
           "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
           "dev": true,
           "requires": {
@@ -2691,7 +2685,7 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
           "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
           "dev": true,
           "requires": {
@@ -2700,7 +2694,7 @@
         },
         "@babel/helper-module-imports": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.44.tgz",
           "integrity": "sha512-V95wi6rCffcLM46XdaUJHRc3D/XSvfsQshedaX1riHQCbs0uVopdswXrykwB6E/QEPfUGxXfs7l5GubupOi+Cw==",
           "dev": true,
           "requires": {
@@ -2710,13 +2704,13 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz",
           "integrity": "sha512-k0hZ8w9N3b0Psmlw0bB7U9Hwqc+/hh7yOPFyLi5KAX9pRZ9i+UbTg6DxsVLVuITvF/M1UZNrq7vatrlEw/IPMg==",
           "dev": true
         },
         "@babel/highlight": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
           "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
@@ -2740,7 +2734,7 @@
         },
         "@babel/plugin-proposal-class-properties": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.44.tgz",
           "integrity": "sha512-IQ9kUIPg4iKDPkVKHvN8EAiRa5qH6+fUqzWPMtsDzmXD2Rpdj0FtR/I0rJkqcutYxneNwfDJFsgTvmFixClSww==",
           "dev": true,
           "requires": {
@@ -2751,7 +2745,7 @@
         },
         "@babel/plugin-proposal-export-default-from": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0-beta.44.tgz",
           "integrity": "sha512-MjcjzVhPMqo9aeWJHnDWW1yqf1uFEErXSHvoeFkaIKYuZnsCZAxE7a7/A4nvAPQPozO6/XrStd4ZJ7aUK1szNQ==",
           "dev": true,
           "requires": {
@@ -2761,7 +2755,7 @@
         },
         "@babel/plugin-proposal-export-namespace-from": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.44.tgz",
           "integrity": "sha512-rEU/M4gaeJRD/ReYkKukuDnAqyf0rMYlkk8IaLkvLgBgE/74+BFz9S239ueBIcmSZdTrAefdG/cpoxal0KkkTw==",
           "dev": true,
           "requires": {
@@ -2771,7 +2765,7 @@
         },
         "@babel/plugin-syntax-class-properties": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.44.tgz",
           "integrity": "sha512-lyojjfVoXuL+Oa95TSVWyf5fMO+JzvMpbFQaZN+voWajMt+Cq3lx8N5JszjlcQzBOZOffqjzMxlAKhNVw95ufA==",
           "dev": true,
           "requires": {
@@ -2780,7 +2774,7 @@
         },
         "@babel/plugin-syntax-export-default-from": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0-beta.44.tgz",
           "integrity": "sha512-uUfDMTgOko1ZU47/chvEZTHCbyG9hpHR+U1jZ4SAlgdKtAK72MdGBKwnO3eesMBaK1CaA/379r0lMiqEuIvcYg==",
           "dev": true,
           "requires": {
@@ -2789,7 +2783,7 @@
         },
         "@babel/plugin-syntax-export-namespace-from": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.44.tgz",
           "integrity": "sha512-4iZY3bWvP47w9euEpu/XJ03PKhiLgQWpfNjQFAIvke+WJsyeZ8jeEfQF8AsMiLth9FgrWWyKAQo1PNurlR7e7w==",
           "dev": true,
           "requires": {
@@ -2798,7 +2792,7 @@
         },
         "@babel/plugin-transform-runtime": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.44.tgz",
           "integrity": "sha512-Bb7CfWE8TByfSP1wYUe4XJb7zlzv3zsw4MI0DhdrzQ2Xh1YCdz1pWdd6LRLsmSDnfnPSs2KvydTs7yPu0yqcGQ==",
           "dev": true,
           "requires": {
@@ -2808,7 +2802,7 @@
         },
         "@babel/template": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
           "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
           "dev": true,
           "requires": {
@@ -2820,7 +2814,7 @@
         },
         "@babel/types": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
           "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
@@ -2984,7 +2978,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3006,7 +3000,7 @@
     },
     "babel-eslint": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-7.1.1.tgz",
       "integrity": "sha1-imqITwhapwYK9pz8dzQcL5k3D7I=",
       "dev": true,
       "requires": {
@@ -3853,7 +3847,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4062,7 +4056,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
@@ -4480,7 +4474,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -4740,7 +4734,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4977,7 +4971,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4992,7 +4986,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -5278,9 +5272,9 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
       "requires": {
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6"
@@ -5507,7 +5501,7 @@
     },
     "css-loader": {
       "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.1.tgz",
+      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.26.1.tgz",
       "integrity": "sha1-K6fyATG5NZdJaz6btQB4WknNKeo=",
       "dev": true,
       "requires": {
@@ -6917,7 +6911,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -7580,7 +7574,7 @@
     },
     "file-loader": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
       "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
       "dev": true,
       "requires": {
@@ -7930,7 +7924,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7951,12 +7946,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7971,17 +7968,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8098,7 +8098,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8110,6 +8111,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8124,6 +8126,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8131,12 +8134,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8155,6 +8160,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8235,7 +8241,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8247,6 +8254,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8332,7 +8340,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8368,6 +8377,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8387,6 +8397,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8430,12 +8441,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8662,13 +8675,13 @@
       "dependencies": {
         "minimist": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
           "dev": true
         },
         "yargs": {
           "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
           "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
           "dev": true,
           "requires": {
@@ -10114,7 +10127,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -11340,7 +11353,7 @@
     },
     "koa-webpack": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/koa-webpack/-/koa-webpack-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/koa-webpack/-/koa-webpack-3.0.2.tgz",
       "integrity": "sha512-SZIhsNOnBVXgspYFfuG/MQ2Orbih97sHxNtswKV5xV2P7CLhvNNzfZFRegaEjQyGQYqWrxbkYRhVcYx83O0p9A==",
       "dev": true,
       "requires": {
@@ -11784,6 +11797,11 @@
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -11796,17 +11814,30 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -12286,7 +12317,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -12350,7 +12381,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -12398,7 +12429,7 @@
     },
     "mini-css-extract-plugin": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.0.tgz",
       "integrity": "sha512-2Zik6PhUZ/MbiboG6SDS9UTPL4XXy4qnyGjSdCIWRrr8xb6PwLtHE+AYOjkXJWdF0OG8vo/yrJ8CgS5WbMpzIg==",
       "dev": true,
       "requires": {
@@ -12872,7 +12903,7 @@
     },
     "ngrok": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-2.2.4.tgz",
+      "resolved": "http://registry.npmjs.org/ngrok/-/ngrok-2.2.4.tgz",
       "integrity": "sha1-ZHTZR7JIO/Igf+BUZkB6RlfL8jY=",
       "dev": true,
       "requires": {
@@ -12886,7 +12917,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
@@ -13060,7 +13091,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -13071,7 +13102,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -13190,6 +13221,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -13514,7 +13546,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -13598,6 +13631,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -13644,7 +13678,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -13910,7 +13945,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -14583,7 +14619,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -14604,7 +14640,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -15848,7 +15884,7 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
@@ -17872,7 +17908,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
@@ -18498,7 +18534,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -18536,7 +18572,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -20503,7 +20539,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
@@ -20667,7 +20703,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -20747,7 +20783,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -20831,7 +20867,7 @@
         },
         "inquirer": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
@@ -21006,7 +21042,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -22044,7 +22080,7 @@
     },
     "webpack-stats-plugin": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz",
       "integrity": "sha512-OYMZLpZrK/qLA79NE4kC4DCt85h/5ipvWJcsefKe9MMw0qU4/ck/IJg+4OmWA+5EfrZZpHXDq92IptfYDWVfkw==",
       "dev": true
     },
@@ -22324,7 +22360,7 @@
     },
     "ws": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
@@ -22411,7 +22447,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -22491,7 +22527,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -22747,7 +22783,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "auth0-extension": {
     "externals": [
-      "auth0-extension-tools@1.3.1",
+      "auth0-extension-tools@1.3.2",
       "bluebird@3.4.6",
       "compression@1.4.4",
       "delegates@0.1.0",
@@ -69,8 +69,8 @@
   },
   "dependencies": {
     "auth0": "^2.1.0",
-    "auth0-extension-express-tools": "^1.1.7",
-    "auth0-extension-tools": "^1.3.1",
+    "auth0-extension-express-tools": "^1.1.9",
+    "auth0-extension-tools": "^1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "axios": "0.15.2",
     "bluebird": "^3.4.0",

--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -50,7 +50,11 @@ export default (auth0, storage) => {
 
         return result;
       })
-      .then(apps => res.json(apps))
+      .then(apps => {
+        const result = [];
+        _.each(apps, (app, id) => result.push({ ...app, id }));
+        return res.json(result);
+      })
       .catch(next);
   });
 
@@ -59,7 +63,11 @@ export default (auth0, storage) => {
    */
   api.get('/all', requireScope('manage:applications'), (req, res, next) => {
     storage.read()
-      .then(apps => res.json(apps.applications || {}))
+      .then(apps => {
+        const applications = [];
+        _.each(apps.applications || {}, (app, id) => applications.push({ ...app, id }));
+        return res.json(applications);
+      })
       .catch(next);
   });
 

--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -50,11 +50,7 @@ export default (auth0, storage) => {
 
         return result;
       })
-      .then(apps => {
-        const result = [];
-        _.each(apps, (app, id) => result.push({ ...app, id }));
-        return res.json(result);
-      })
+      .then(apps => res.json(_.map(apps, (app, id) => ({ ...app, id }))))
       .catch(next);
   });
 
@@ -63,11 +59,7 @@ export default (auth0, storage) => {
    */
   api.get('/all', requireScope('manage:applications'), (req, res, next) => {
     storage.read()
-      .then(apps => {
-        const applications = [];
-        _.each(apps.applications || {}, (app, id) => applications.push({ ...app, id }));
-        return res.json(applications);
-      })
+      .then(apps => res.json(_.map(apps.applications || {}, (app, id) => ({ ...app, id }))))
       .catch(next);
   });
 

--- a/tests/server/routes/applications.tests.js
+++ b/tests/server/routes/applications.tests.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import expect from 'expect';
 import Promise from 'bluebird';
 import request from 'supertest';
@@ -104,7 +105,7 @@ describe('#applications router', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err;
-          expect(res.body).toEqual(defaultApps);
+          expect(res.body).toEqual(_.map(defaultApps, (item, id) => ({ ...item, id })));
           done();
         });
     });
@@ -116,7 +117,7 @@ describe('#applications router', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err;
-          expect(res.body).toEqual({ appOne: defaultApps.appOne });
+          expect(res.body).toEqual([ { ...defaultApps.appOne, id: 'appOne' } ]);
           done();
         });
     });


### PR DESCRIPTION
## ✏️ Changes
It seems `react` is breaking object elements order, when there are 9 or more elements. Because of that, extension should respond with array of apps (instead of object) to preserve order.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1551373277008700
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  