### PR TITLE
Update custom domains config name as `AUTH0_CUSTOM_DOMAIN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.2] - 2019-04-10
+## [2.3.0] - 2019-04-10
 
 ### Fixed
 - Update custom domains config name as `AUTH0_CUSTOM_DOMAIN`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2019-04-10
+
+### Fixed
+- Update custom domains config name as `AUTH0_CUSTOM_DOMAIN`
+
 ## [2.2.1] - 2019-04-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19439,7 +19439,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "This extension provides your users with a dashboard for all of their applications.",
   "engines": {
     "node": ">=4.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "This extension provides your users with a dashboard for all of their applications.",
   "engines": {
     "node": ">=4.x"

--- a/server/lib/authenticationUrl.js
+++ b/server/lib/authenticationUrl.js
@@ -3,7 +3,7 @@ import config from './config';
 export default (app) => {
   const authProtocol = app.type;
   const callback = app.callback || '';
-  const domain = config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN');
+  const domain = config('AUTH0_CUSTOM_DOMAIN');
   const clientId = app.client;
   const responseType = app.response_type || 'code';
   const scope = app.scope || 'openid';

--- a/server/lib/authenticationUrl.js
+++ b/server/lib/authenticationUrl.js
@@ -3,7 +3,7 @@ import config from './config';
 export default (app) => {
   const authProtocol = app.type;
   const callback = app.callback || '';
-  const domain = config('AUTH0_ISSUER_DOMAIN');
+  const domain = config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN');
   const clientId = app.client;
   const responseType = app.response_type || 'code';
   const scope = app.scope || 'openid';

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -20,8 +20,8 @@ const config = (key) => {
     throw new Error('A configuration provider has not been set');
   }
 
-  if (key === 'AUTH0_ISSUER_DOMAIN') {
-    return currentProvider('AUTH0_ISSUER_DOMAIN') || currentProvider('AUTH0_DOMAIN');
+  if (key === 'AUTH0_CUSTOM_DOMAIN') {
+    return currentProvider('AUTH0_CUSTOM_DOMAIN') || currentProvider('AUTH0_ISSUER_DOMAIN') || currentProvider('AUTH0_DOMAIN');
   }
 
   if (key === 'IS_APPLIANCE') {

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -21,7 +21,7 @@ const config = (key) => {
   }
 
   if (key === 'AUTH0_CUSTOM_DOMAIN') {
-    return currentProvider('AUTH0_CUSTOM_DOMAIN') || currentProvider('AUTH0_ISSUER_DOMAIN') || currentProvider('AUTH0_DOMAIN');
+    return currentProvider('AUTH0_CUSTOM_DOMAIN') || currentProvider('AUTH0_DOMAIN');
   }
 
   if (key === 'IS_APPLIANCE') {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -11,15 +11,9 @@ import authorization from './authorization';
 export default (storage) => {
   const api = Router();
 
-
-  let domain = config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN');
-  if (config('IS_APPLIANCE')) {
-    domain = config('AUTH0_DOMAIN');
-  }
-
   // Allow end users to authenticate.
   api.use(middlewares.authenticateUsers.optional({
-    domain,
+    domain: config('IS_APPLIANCE') ? config('AUTH0_DOMAIN') : config('AUTH0_CUSTOM_DOMAIN'),
     audience: config('API_AUDIENCE') || 'urn:auth0-sso-dashboard',
     credentialsRequired: false,
     onLoginSuccess: (req, res, next) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -11,9 +11,15 @@ import authorization from './authorization';
 export default (storage) => {
   const api = Router();
 
+
+  let domain = config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN');
+  if (config('IS_APPLIANCE')) {
+    domain = config('AUTH0_DOMAIN');
+  }
+
   // Allow end users to authenticate.
   api.use(middlewares.authenticateUsers.optional({
-    domain: config('IS_APPLIANCE') ? config('AUTH0_DOMAIN') : config('AUTH0_ISSUER_DOMAIN'),
+    domain,
     audience: config('API_AUDIENCE') || 'urn:auth0-sso-dashboard',
     credentialsRequired: false,
     onLoginSuccess: (req, res, next) => {

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -45,7 +45,7 @@ export default () => {
     }
 
     const settings = {
-      AUTH0_CUSTOM_DOMAIN: config('AUTH0_ISSUER_DOMAIN'),
+      AUTH0_CUSTOM_DOMAIN: config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN'),
       AUTH0_DOMAIN: config('AUTH0_DOMAIN'),
       IS_APPLIANCE: config('IS_APPLIANCE'),
       AUTH0_CLIENT_ID: config('EXTENSION_CLIENT_ID'),

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -45,7 +45,7 @@ export default () => {
     }
 
     const settings = {
-      AUTH0_CUSTOM_DOMAIN: config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_ISSUER_DOMAIN'),
+      AUTH0_CUSTOM_DOMAIN: config('AUTH0_CUSTOM_DOMAIN'),
       AUTH0_DOMAIN: config('AUTH0_DOMAIN'),
       IS_APPLIANCE: config('IS_APPLIANCE'),
       AUTH0_CLIENT_ID: config('EXTENSION_CLIENT_ID'),

--- a/tests/mocha.js
+++ b/tests/mocha.js
@@ -5,7 +5,7 @@ const nodeTarget = '4.2.0';
 
 // Register babel so that it will transpile ES6 to ES5
 // before our tests run.
-require('babel-polyfill');
+require('@babel/polyfill');
 
 require('@babel/register')({
   presets: [

--- a/webtask.json
+++ b/webtask.json
@@ -1,8 +1,8 @@
 {
   "title": "SSO Dashboard",
   "name": "auth0-sso-dashboard",
-  "version": "2.2.1",
-  "preVersion": "2.1.1",
+  "version": "2.3.0",
+  "preVersion": "2.2.1",
   "author": "Auth0",
   "useHashName": false,
   "description": "This extension provides your users with a dashboard for all of their applications.",
@@ -40,7 +40,8 @@
     "AUTH0_CUSTOM_DOMAIN": {
       "description": "Custom domain",
       "example": "example.com",
-      "required": false
+      "required": false,
+      "former": "AUTH0_ISSUER_DOMAIN"
     },
     "ALLOW_AUTHZ": {
       "description": "Allow enabling of Authorization Extension integration (Deprecated)",

--- a/webtask.json
+++ b/webtask.json
@@ -37,7 +37,7 @@
       "example": "https://cdn.fabrikam.com/static/extensions/theme/fabrikam.css",
       "required": false
     },
-    "AUTH0_ISSUER_DOMAIN": {
+    "AUTH0_CUSTOM_DOMAIN": {
       "description": "Custom domain",
       "example": "example.com",
       "required": false


### PR DESCRIPTION
## ✏️ Changes
  
Update custom domains config name as `AUTH0_CUSTOM_DOMAIN`
`AUTH0_ISSUER_DOMAIN` is dropped completely from the code
  
## 🔗 References

For consistency with the Delegated Admin Extension
https://github.com/auth0-extensions/auth0-delegated-administration-extension/pull/168
  

## 🎯 Testing
   
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage

## 🚀 Deployment
🚫 This must be deployed after https://github.com/auth0/extension-gallery/pull/50
  