### PR TITLE
[CF-447] Use paginated requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1486,6 +1486,67 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
     "@types/babel-types": {
@@ -12489,6 +12550,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
@@ -13087,6 +13154,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -14230,6 +14303,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "9.0.22",
@@ -19006,6 +19109,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "redux-simple-router": "^2.0.4",
     "redux-static": "^1.0.0",
     "rimraf": "^2.5.2",
+    "sinon": "^9.0.2",
     "style-loader": "^0.13.1",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "url-loader": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-dashboard",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "This extension provides your users with a dashboard for all of their applications.",
   "engines": {
     "node": ">=4.x"

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -1,3 +1,4 @@
+import { snakeCase } from 'lodash';
 import Promise from 'bluebird';
 import { ArgumentError } from 'auth0-extension-tools';
 
@@ -21,7 +22,7 @@ export default function (client, entity, opts = {}, perPage = 100, concurrency =
       .then((response) => {
         total = response.total || 0;
         pageCount = Math.ceil(total / perPage);
-        const data = response[entity] || response || [];
+        const data = response[entity] || response[snakeCase(entity)] || response || [];
         data.forEach(item => result.push(item));
         return null;
       });

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -135,8 +135,16 @@ const getToken = (req) => {
 
 const makeRequest = (req, path, method, payload) =>
   new Promise((resolve, reject) => getToken(req).then((token) => {
-    request(method, `https://${config('AUTH0_DOMAIN')}/api/v2/${path}`)
-      .send(payload || {})
+    let request = request(method, `https://${config('AUTH0_DOMAIN')}/api/v2/${path}`);
+    if (method === 'GET') {
+      if (payload) {
+        request = request.query(payload);
+      }
+    } else {
+      request = request.send(payload || {})
+    }
+
+    request
       .set('Content-Type', 'application/json')
       .set('Authorization', `Bearer ${token}`)
       .end((err, res) => {
@@ -183,7 +191,7 @@ export const deleteResourceServer = req =>
     });
 
 const getGrantId = req =>
-  makeRequest(req, 'client-grants', 'GET')
+  makeRequest(req, 'client-grants', 'GET', { client_id: config('AUTH0_CLIENT_ID'), audience: 'urn:auth0-authz-api' })
     .then(grants => grants.filter(item => (item.client_id === config('AUTH0_CLIENT_ID') && item.audience === 'urn:auth0-authz-api')))
     .then(grants => grants[0] && grants[0].id);
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -43,7 +43,7 @@ export default (storage) => {
   });
   api.use('/applications', applications(auth0, storage));
   api.use('/groups', groups(storage));
-  api.use('/authorization', authorization(storage));
+  api.use('/authorization', authorization(auth0, storage));
   api.use('/connections', connections(auth0));
   api.get('/status', (req, res) => {
     res.json({ isAdmin: (req.user.scope && req.user.scope.indexOf('manage:applications') > -1) });

--- a/server/routes/authorization.js
+++ b/server/routes/authorization.js
@@ -4,10 +4,10 @@ import config from '../lib/config';
 import * as authorization from '../lib/authorization';
 import { requireScope } from '../lib/middlewares';
 
-export default (storage) => {
+export default (auth0, storage) => {
   const api = Router();
 
-  api.get('/', requireScope('manage:authorization'), (req, res, next) => {
+  api.get('/', auth0, requireScope('manage:authorization'), (req, res, next) => {
     if (!config('ALLOW_AUTHZ')) {
       return res.json({ authorizationApiAvailable: false });
     }
@@ -17,7 +17,7 @@ export default (storage) => {
       .catch(next);
   });
 
-  api.post('/', requireScope('manage:authorization'), (req, res, next) => {
+  api.post('/', auth0, requireScope('manage:authorization'), (req, res, next) => {
     if (!config('ALLOW_AUTHZ')) {
       return next();
     }
@@ -27,7 +27,7 @@ export default (storage) => {
       .catch(next);
   });
 
-  api.delete('/', requireScope('manage:authorization'), (req, res, next) => {
+  api.delete('/', auth0, requireScope('manage:authorization'), (req, res, next) => {
     if (!config('ALLOW_AUTHZ')) {
       return next();
     }

--- a/tests/server/lib/queries.tests.js
+++ b/tests/server/lib/queries.tests.js
@@ -1,0 +1,58 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import nock from 'nock';
+import { setProvider } from '../../../server/lib/config';
+import { getResourceServer, removeGrant } from '../../../server/lib/queries';
+
+describe('queries', () => {
+  before(() => {
+    setProvider(() => 'auth0.example.com');
+  });
+
+  describe('getResourceServer', () => {
+    it('should fetch the resource servers with pagination', () => {
+      const req =  {
+        auth0: {
+          resourceServers: {
+            getAll: sinon.spy(() => {
+              return Promise.resolve({ total: 1, resource_servers: [{ identifier: 'http://audience' }] });
+            })
+          }
+        }
+      };
+      return getResourceServer(req, 'http://audience').then((resourceServer) => {
+        expect(resourceServer).to.eql({ identifier: 'http://audience' });
+        sinon.assert.calledOnce(req.auth0.resourceServers.getAll);
+        sinon.assert.calledWith(req.auth0.resourceServers.getAll, { include_totals: true, page: 0, per_page: 100 });
+      });
+    });
+  });
+
+  describe('removeGrant', () => {
+    afterEach(() => {
+      nock.restore();
+    });
+
+    it('should delete the grant if it exists', () => {
+      const get = nock('https://auth0.example.com')
+        .get('/api/v2/client-grants')
+        .query({ client_id: 'auth0.example.com',audience: 'urn:auth0-authz-api' })
+        .reply(200, [ { client_id: 'auth0.example.com',audience: 'urn:auth0-authz-api', id: 'id1' }]);
+
+      const del = nock('https://auth0.example.com')
+        .delete('/api/v2/client-grants/id1')
+        .reply(204)
+
+      const req =  {
+        user: {
+          access_token: 'token'
+        }
+      };
+      return removeGrant(req).then(() => {
+        get.done();
+        del.done();
+      });
+    });
+  });
+});

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "SSO Dashboard",
   "name": "auth0-sso-dashboard",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "preVersion": "2.2.1",
   "author": "Auth0",
   "useHashName": false,


### PR DESCRIPTION
## ✏️ Changes
  
Use paginated requests for resource servers and client grants.

The call to resource servers was verified by enabling `ALLOW_AUTHZ` and checking that it fetched results correctly.
    
 ## 🎯 Testing
   
✅ This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
  